### PR TITLE
Increase health check tolerance for AFP mount

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 # Report unhealthy when AFP mount’s keepalive file can’t be accessed
-HEALTHCHECK --interval=45s --timeout=5s --start-period=60s --retries=3 \
+HEALTHCHECK --interval=45s --timeout=15s --start-period=60s --retries=5 \
 CMD ["sh","-c","stat /mnt/timecapsule/.afp_keepalive >/dev/null 2>&1"]
 # Default command handed to the entrypoint
 CMD ["smbd","-F","--no-process-group","--configfile=/etc/samba/smb.conf"]


### PR DESCRIPTION
## Summary
- extend health check timeout and retries to accommodate slow Time Capsule mounts

## Testing
- `buildah bud -t timecapsulemount:test .` *(fails: unable to apply cgroup configuration - read-only file system)*

------
https://chatgpt.com/codex/tasks/task_e_68b560612c30833290d1e6869474e36a